### PR TITLE
Week 3: Schema registry + rest services

### DIFF
--- a/accounting/Gemfile
+++ b/accounting/Gemfile
@@ -42,3 +42,5 @@ gem 'omniauth-oauth2', '~> 1.8'
 gem 'byebug', '~> 11.1', groups: %i[development test]
 
 gem 'karafka', '~> 2.1'
+
+gem 'schema_registry', git: 'https://github.com/davydovanton/event_schema_registry.git', ref: 'fc87185'

--- a/accounting/Gemfile.lock
+++ b/accounting/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/davydovanton/event_schema_registry.git
+  revision: fc871856f3b6268de1d2311587abc2d0dea50b7b
+  ref: fc87185
+  specs:
+    schema_registry (1)
+      json-schema
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -66,6 +74,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.2.2)
@@ -90,6 +100,8 @@ GEM
     io-console (0.6.0)
     irb (1.7.4)
       reline (>= 0.3.6)
+    json-schema (4.0.0)
+      addressable (>= 2.8)
     jwt (2.7.1)
     karafka (2.1.9)
       karafka-core (>= 2.1.1, < 2.2.0)
@@ -146,6 +158,7 @@ GEM
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    public_suffix (5.0.3)
     puma (5.6.7)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -223,6 +236,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 1.0)
   puma (~> 5.0)
   rails (~> 7.0.7)
+  schema_registry!
   sprockets-rails
   sqlite3 (~> 1.4)
   tzinfo-data

--- a/accounting/app/consumers/tasks_consumer.rb
+++ b/accounting/app/consumers/tasks_consumer.rb
@@ -48,7 +48,7 @@ class TasksConsumer < ApplicationConsumer
         task = Task.find_by(public_id: data['public_id'])
         next if task.blank?
 
-        user.update!(user.balance + task.reward)
+        user.update!(balance: user.balance + task.reward)
 
         AuditLog.create!(
           user:,

--- a/accounting/app/consumers/tasks_consumer.rb
+++ b/accounting/app/consumers/tasks_consumer.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class TasksConsumer < ApplicationConsumer
+  def consume
+    messages.each do |message|
+      puts '-' * 80
+      p message
+      puts '-' * 80
+
+      payload = message.payload
+
+      event_name = payload['event_name']
+      data = payload['data']
+
+      case event_name
+      when 'TaskCreated'
+        user = User.find_by(public_id: data['employee_id'])
+
+        task = Task.create!(
+          public_id: data['public_id'],
+          title: data['title'],
+          completed: data['completed'],
+          assign_cost: data['assign_cost'],
+          reward: data['reward'],
+          user:
+        )
+
+        AuditLog.create!(
+          user:,
+          task:,
+          reason: 'TaskCreated',
+          cost: -task.assign_cost
+        )
+
+        user.update!(balance: user.balance - task.assign_cost)
+      when 'TaskUpdated'
+        task = User.find_by(public_id: data['public_id'])
+
+        if data['title'].present?
+          task.update!(
+            title: data['title']
+          )
+        end
+      when 'TaskCompleted'
+        user = User.find_by(public_id: data['employee_id'])
+        next if user.blank?
+
+        task = Task.find_by(public_id: data['public_id'])
+        next if task.blank?
+
+        user.update!(user.balance + task.reward)
+
+        AuditLog.create!(
+          user:,
+          task:,
+          reason: 'TaskCompleted',
+          cost: task.reward
+        )
+      when 'TaskAssigned'
+        user = User.find_by(public_id: data['employee_id'])
+        next if user.blank?
+
+        task = Task.find_by(public_id: data['public_id'])
+        next if task.blank?
+
+        user.update!(balance: user.balance - task.assign_cost)
+
+        AuditLog.create!(
+          user:,
+          task:,
+          reason: 'TaskAssigned',
+          cost: -task.assign_cost
+        )
+      else
+        # store events in DB
+      end
+    end
+  end
+end

--- a/accounting/app/models/audit_log.rb
+++ b/accounting/app/models/audit_log.rb
@@ -3,4 +3,32 @@
 class AuditLog < ApplicationRecord
   belongs_to :user
   belongs_to :task
+
+  before_create do
+    self.public_id = SecureRandom.uuid
+  end
+
+  after_create do
+    # ----------------------------- produce event -----------------------
+    event = {
+      event_id: SecureRandom.uuid,
+      event_version: 1,
+      event_time: Time.now.to_s,
+      producer: 'accounting_service',
+      event_name: 'AuditLogCreated',
+      data: {
+        public_id:,
+        employee_id: user.public_id,
+        task_id: task.public_id,
+        reason:,
+        cost:,
+        created_at:
+      }
+    }
+
+    result = SchemaRegistry.validate_event(event, 'audit_logs.created', version: 1)
+
+    Karafka.producer.produce_sync(payload: event.to_json, topic: 'audit-logs-stream') if result.success?
+    # --------------------------------------------------------------------
+  end
 end

--- a/accounting/app/models/audit_log.rb
+++ b/accounting/app/models/audit_log.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class AuditLog < ApplicationRecord
+  belongs_to :user
+  belongs_to :task
+end

--- a/accounting/app/models/task.rb
+++ b/accounting/app/models/task.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Task < ApplicationRecord
+  belongs_to :user
+
+  scope :in_progress, -> { where(completed: false) }
+  scope :completed, -> { where(completed: true) }
+end

--- a/accounting/config/initializers/schema_registry.rb
+++ b/accounting/config/initializers/schema_registry.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+SchemaRegistry.configure do |config|
+  config.schemas_root_path = Rails.root.join('schemas')
+end

--- a/accounting/db/migrate/20230819215943_create_audit_log.rb
+++ b/accounting/db/migrate/20230819215943_create_audit_log.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateAuditLog < ActiveRecord::Migration[7.0]
+  def change
+    create_table :audit_logs do |t|
+      t.references :user, null: false, foreign_key: true, on_delete: :cascade
+      t.references :task, null: false, foreign_key: true, on_delete: :cascade
+      t.integer :cost, null: false
+      t.string :reason, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/accounting/db/migrate/20230819220107_add_balance_to_user.rb
+++ b/accounting/db/migrate/20230819220107_add_balance_to_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBalanceToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :balance, :integer, null: false, default: 0
+  end
+end

--- a/accounting/db/migrate/20230819221314_create_tasks.rb
+++ b/accounting/db/migrate/20230819221314_create_tasks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateTasks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tasks do |t|
+      t.string :public_id
+      t.string :title
+      t.boolean :completed
+      t.integer :assign_cost, null: false
+      t.integer :reward, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/accounting/db/schema.rb
+++ b/accounting/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,58 +12,59 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_19_221314) do
-  create_table "audit_logs", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "task_id", null: false
-    t.integer "cost", null: false
-    t.string "reason", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["task_id"], name: "index_audit_logs_on_task_id"
-    t.index ["user_id"], name: "index_audit_logs_on_user_id"
+ActiveRecord::Schema[7.0].define(version: 20_230_819_221_314) do
+  create_table 'audit_logs', force: :cascade do |t|
+    t.integer 'user_id', null: false
+    t.integer 'task_id', null: false
+    t.string 'public_id'
+    t.integer 'cost', null: false
+    t.string 'reason', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['task_id'], name: 'index_audit_logs_on_task_id'
+    t.index ['user_id'], name: 'index_audit_logs_on_user_id'
   end
 
-  create_table "auth_identities", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "provider", null: false
-    t.string "login", null: false
-    t.string "token"
-    t.string "uid"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_auth_identities_on_user_id"
+  create_table 'auth_identities', force: :cascade do |t|
+    t.integer 'user_id', null: false
+    t.string 'provider', null: false
+    t.string 'login', null: false
+    t.string 'token'
+    t.string 'uid'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_auth_identities_on_user_id'
   end
 
-  create_table "dashboards", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'dashboards', force: :cascade do |t|
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "tasks", force: :cascade do |t|
-    t.string "public_id"
-    t.string "title"
-    t.boolean "completed"
-    t.integer "assign_cost", null: false
-    t.integer "reward", null: false
-    t.integer "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_tasks_on_user_id"
+  create_table 'tasks', force: :cascade do |t|
+    t.string 'public_id'
+    t.string 'title'
+    t.boolean 'completed'
+    t.integer 'assign_cost', null: false
+    t.integer 'reward', null: false
+    t.integer 'user_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_tasks_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "full_name"
-    t.string "public_id"
-    t.integer "role"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "balance", default: 0, null: false
+  create_table 'users', force: :cascade do |t|
+    t.string 'email', null: false
+    t.string 'full_name'
+    t.string 'public_id'
+    t.integer 'role'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'balance', default: 0, null: false
   end
 
-  add_foreign_key "audit_logs", "tasks"
-  add_foreign_key "audit_logs", "users"
-  add_foreign_key "auth_identities", "users"
-  add_foreign_key "tasks", "users"
+  add_foreign_key 'audit_logs', 'tasks'
+  add_foreign_key 'audit_logs', 'users'
+  add_foreign_key 'auth_identities', 'users'
+  add_foreign_key 'tasks', 'users'
 end

--- a/accounting/db/schema.rb
+++ b/accounting/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,31 +10,58 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_819_213_014) do
-  create_table 'auth_identities', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider', null: false
-    t.string 'login', null: false
-    t.string 'token'
-    t.string 'uid'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_auth_identities_on_user_id'
+ActiveRecord::Schema[7.0].define(version: 2023_08_19_221314) do
+  create_table "audit_logs", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "task_id", null: false
+    t.integer "cost", null: false
+    t.string "reason", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_audit_logs_on_task_id"
+    t.index ["user_id"], name: "index_audit_logs_on_user_id"
   end
 
-  create_table 'dashboards', force: :cascade do |t|
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "auth_identities", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "login", null: false
+    t.string "token"
+    t.string "uid"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_auth_identities_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'full_name'
-    t.string 'public_id'
-    t.integer 'role'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "dashboards", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  add_foreign_key 'auth_identities', 'users'
+  create_table "tasks", force: :cascade do |t|
+    t.string "public_id"
+    t.string "title"
+    t.boolean "completed"
+    t.integer "assign_cost", null: false
+    t.integer "reward", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "full_name"
+    t.string "public_id"
+    t.integer "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "balance", default: 0, null: false
+  end
+
+  add_foreign_key "audit_logs", "tasks"
+  add_foreign_key "audit_logs", "users"
+  add_foreign_key "auth_identities", "users"
+  add_foreign_key "tasks", "users"
 end

--- a/accounting/karafka.rb
+++ b/accounting/karafka.rb
@@ -32,5 +32,9 @@ class KarafkaApp < Karafka::App
     topic :'users-stream' do
       consumer UsersConsumer
     end
+
+    topic :'tasks-stream' do
+      consumer TasksConsumer
+    end
   end
 end

--- a/accounting/schemas/audit_logs/created/1.json
+++ b/accounting/schemas/audit_logs/created/1.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Audit_logs.Created.v1",
+  "description": "json schema for create audit log events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "employee_id": {
+          "type": "string"
+        },
+        "task_id": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "cost": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "public_id",
+        "employee_id",
+        "task_id",
+        "reason",
+        "cost"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["AuditLogCreated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/accounting/schemas/balances/created/1.json
+++ b/accounting/schemas/balances/created/1.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Balances.Created.v1",
+  "description": "json schema for BE balances log events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "employee_id": {
+          "type": "string"
+        },
+        "balance": {
+          "type": "integer"
+        },
+        "created_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "employee_id",
+        "balance",
+        "created_at"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["BalanceCreated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/accounting/schemas/balances/updated/1.json
+++ b/accounting/schemas/balances/updated/1.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Balances.Updated.v1",
+  "description": "json schema for BE balances log events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "employee_id": {
+          "type": "string"
+        },
+        "balance": {
+          "type": "integer"
+        },
+        "created_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "employee_id",
+        "balance",
+        "created_at"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["BalanceUpdated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/analytics/app/consumers/audit_logs_consumer.rb
+++ b/analytics/app/consumers/audit_logs_consumer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AuditLogsConsumer < ApplicationConsumer
+  def consume
+    messages.each do |message|
+      puts '-' * 80
+      p message
+      puts '-' * 80
+
+      payload = message.payload
+
+      event_name = payload['event_name']
+      data = payload['data']
+
+      case event_name
+      when 'AuditLogCreated'
+        user = User.find_by(public_id: data['employee_id'])
+
+        AuditLog.create!(
+          user: user,
+          task_public_id: data['task_id'],
+          reason: data['reason'],
+          cost: data['cost'],
+          created_at: data['created_at']
+        )
+      else
+        # store events in DB
+      end
+    end
+  end
+end

--- a/analytics/app/consumers/balance_logs_consumer.rb
+++ b/analytics/app/consumers/balance_logs_consumer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class BalanceLogsConsumer < ApplicationConsumer
+  def consume
+    messages.each do |message|
+      puts '-' * 80
+      p message
+      puts '-' * 80
+
+      payload = message.payload
+
+      event_name = payload['event_name']
+      data = payload['data']
+
+      case event_name
+      when 'BalanceCreated'
+        user = User.find_by(public_id: data['employee_id'])
+
+        BalanceLog.create!(
+          user: user,
+          balance: data['balance'],
+          created_at: data['created_at']
+        )
+      when 'BalanceUpdated'
+        user = User.find_by(public_id: data['employee_id'])
+
+        BalanceLog.create!(
+          user: user,
+          balance: data['balance'],
+          created_at: data['created_at']
+        )
+      else
+        # store events in DB
+      end
+    end
+  end
+end

--- a/analytics/app/models/audit_log.rb
+++ b/analytics/app/models/audit_log.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AuditLog < ApplicationRecord
+  belongs_to :user
+end

--- a/analytics/app/models/balance_log.rb
+++ b/analytics/app/models/balance_log.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class BalanceLog < ApplicationRecord
+  belongs_to :user
+end

--- a/analytics/db/migrate/20230819215943_create_audit_log.rb
+++ b/analytics/db/migrate/20230819215943_create_audit_log.rb
@@ -4,8 +4,9 @@ class CreateAuditLog < ActiveRecord::Migration[7.0]
   def change
     create_table :audit_logs do |t|
       t.references :user, null: false, foreign_key: true, on_delete: :cascade
-      t.references :task, null: false, foreign_key: true, on_delete: :cascade
+
       t.string :public_id
+      t.string :task_public_id, null: false
       t.integer :cost, null: false
       t.string :reason, null: false
 

--- a/analytics/db/migrate/20230820001407_create_balance_logs.rb
+++ b/analytics/db/migrate/20230820001407_create_balance_logs.rb
@@ -1,0 +1,11 @@
+class CreateBalanceLogs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :balance_logs do |t|
+      t.references :user, null: false, foreign_key: true, on_delete: :cascade
+
+      t.integer :balance, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/analytics/db/schema.rb
+++ b/analytics/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,31 +10,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_819_213_344) do
-  create_table 'auth_identities', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider', null: false
-    t.string 'login', null: false
-    t.string 'token'
-    t.string 'uid'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_auth_identities_on_user_id'
+ActiveRecord::Schema[7.0].define(version: 2023_08_20_001407) do
+  create_table "audit_logs", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "public_id"
+    t.string "task_public_id", null: false
+    t.integer "cost", null: false
+    t.string "reason", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_audit_logs_on_user_id"
   end
 
-  create_table 'dashboards', force: :cascade do |t|
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "auth_identities", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "login", null: false
+    t.string "token"
+    t.string "uid"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_auth_identities_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'full_name'
-    t.string 'public_id'
-    t.integer 'role'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "balance_logs", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "balance", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_balance_logs_on_user_id"
   end
 
-  add_foreign_key 'auth_identities', 'users'
+  create_table "dashboards", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "full_name"
+    t.string "public_id"
+    t.integer "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "audit_logs", "users"
+  add_foreign_key "auth_identities", "users"
+  add_foreign_key "balance_logs", "users"
 end

--- a/analytics/karafka.rb
+++ b/analytics/karafka.rb
@@ -36,5 +36,13 @@ class KarafkaApp < Karafka::App
     topic :'users-stream' do
       consumer UsersConsumer
     end
+
+    topic :'audit-logs-stream' do
+      consumer AuditLogsConsumer
+    end
+
+    topic :'balance-logs-stream' do
+      consumer BalanceLogsConsumer
+    end
   end
 end

--- a/auth/Gemfile
+++ b/auth/Gemfile
@@ -23,6 +23,9 @@ gem 'cssbundling-rails'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
+# TODO: upgrade when initializers will be merged
+gem 'schema_registry', git: 'https://github.com/davydovanton/event_schema_registry.git', ref: 'fc87185'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/auth/Gemfile.lock
+++ b/auth/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/davydovanton/event_schema_registry.git
+  revision: fc871856f3b6268de1d2311587abc2d0dea50b7b
+  ref: fc87185
+  specs:
+    schema_registry (1)
+      json-schema
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -66,6 +74,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
     bcrypt (3.1.19)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
@@ -98,6 +108,8 @@ GEM
     io-console (0.6.0)
     irb (1.7.4)
       reline (>= 0.3.6)
+    json-schema (4.0.0)
+      addressable (>= 2.8)
     jwt (2.7.1)
     karafka (2.1.9)
       karafka-core (>= 2.1.1, < 2.2.0)
@@ -152,6 +164,7 @@ GEM
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
+    public_suffix (5.0.3)
     puma (5.6.6)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -233,6 +246,7 @@ DEPENDENCIES
   omniauth-oauth2 (~> 1.8)
   puma (~> 5.0)
   rails (~> 7.0.7)
+  schema_registry!
   sprockets-rails
   sqlite3 (~> 1.4)
   tzinfo-data

--- a/auth/config/initializers/schema_registry.rb
+++ b/auth/config/initializers/schema_registry.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+SchemaRegistry.configure do |config|
+  config.schemas_root_path = Rails.root.join('schemas')
+end

--- a/auth/schemas/users/created/1.json
+++ b/auth/schemas/users/created/1.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Users.Created.v1",
+  "description": "json schema for CUD users events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "full_name": {
+          "type": ["string", "null"]
+        },
+        "role": {
+          "type": ["integer", "null"]
+        }
+      },
+      "required": [
+        "public_id",
+        "email"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["UserCreated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/auth/schemas/users/deleted/1.json
+++ b/auth/schemas/users/deleted/1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Users.Deleted.v1",
+  "description": "json schema for CUD users events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["UserDeleted"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/auth/schemas/users/role_changed/1.json
+++ b/auth/schemas/users/role_changed/1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Users.RoleChanged.v1",
+  "description": "json schema for BE users events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "role": {
+          "type": ["integer", "null"]
+        }
+      },
+      "required": [
+        "public_id",
+        "role"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["UserRoleChanged"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/auth/schemas/users/updated/1.json
+++ b/auth/schemas/users/updated/1.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Users.Updated.v1",
+  "description": "json schema for CUD users events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "full_name": {
+          "type": ["string", "null"]
+        },
+        "role": {
+          "type": ["integer", "null"]
+        }
+      },
+      "required": [
+        "public_id"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["UserUpdated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/tasks/Gemfile
+++ b/tasks/Gemfile
@@ -42,3 +42,5 @@ gem 'omniauth-oauth2', '~> 1.8'
 gem 'byebug', '~> 11.1', groups: %i[development test]
 
 gem 'karafka', '~> 2.1'
+
+gem 'schema_registry', git: 'https://github.com/davydovanton/event_schema_registry.git', ref: 'fc87185'

--- a/tasks/Gemfile.lock
+++ b/tasks/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/davydovanton/event_schema_registry.git
+  revision: fc871856f3b6268de1d2311587abc2d0dea50b7b
+  ref: fc87185
+  specs:
+    schema_registry (1)
+      json-schema
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -66,6 +74,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.2.2)
@@ -90,6 +100,8 @@ GEM
     io-console (0.6.0)
     irb (1.7.4)
       reline (>= 0.3.6)
+    json-schema (4.0.0)
+      addressable (>= 2.8)
     jwt (2.7.1)
     karafka (2.1.9)
       karafka-core (>= 2.1.1, < 2.2.0)
@@ -146,6 +158,7 @@ GEM
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    public_suffix (5.0.3)
     puma (5.6.6)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -223,6 +236,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 1.0)
   puma (~> 5.0)
   rails (~> 7.0.7)
+  schema_registry!
   sprockets-rails
   sqlite3 (~> 1.4)
   tzinfo-data

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -5,6 +5,7 @@ class Task < ApplicationRecord
 
   before_create do
     self.public_id = SecureRandom.uuid
+    self.jira_id = "POPUG-#{id}"
   end
 
   scope :in_progress, -> { where(completed: false) }

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -7,23 +7,6 @@ class Task < ApplicationRecord
     self.public_id = SecureRandom.uuid
   end
 
-  after_create do
-    # ----------------------------- produce event -----------------------
-    event = {
-      event_name: 'TaskCreated',
-      data: {
-        public_id:,
-        title:,
-        description:,
-        completed:,
-        user_id:
-      }
-    }
-
-    Karafka.producer.produce_sync(payload: event.to_json, topic: 'tasks-stream')
-    # --------------------------------------------------------------------
-  end
-
   scope :in_progress, -> { where(completed: false) }
   scope :completed, -> { where(completed: true) }
 end

--- a/tasks/config/initializers/schema_registry.rb
+++ b/tasks/config/initializers/schema_registry.rb
@@ -3,3 +3,9 @@
 SchemaRegistry.configure do |config|
   config.schemas_root_path = Rails.root.join('schemas')
 end
+
+format_proc = lambda { |value|
+  raise JSON::Schema::CustomFormatError, 'Title should not contain []' if (value.include? '[') || (value.include? ']')
+}
+
+JSON::Validator.register_format_validator('jira-checker', format_proc)

--- a/tasks/config/initializers/schema_registry.rb
+++ b/tasks/config/initializers/schema_registry.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+SchemaRegistry.configure do |config|
+  config.schemas_root_path = Rails.root.join('schemas')
+end

--- a/tasks/db/migrate/20230820004827_add_jira_id_to_tasks.rb
+++ b/tasks/db/migrate/20230820004827_add_jira_id_to_tasks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddJiraIdToTasks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tasks, :jira_id, :string
+  end
+end

--- a/tasks/db/schema.rb
+++ b/tasks/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_814_212_617) do
+ActiveRecord::Schema[7.0].define(version: 20_230_820_004_827) do
   create_table 'auth_identities', force: :cascade do |t|
     t.integer 'user_id', null: false
     t.string 'provider', null: false
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 20_230_814_212_617) do
     t.integer 'user_id', null: false
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.string 'jira_id'
     t.index ['user_id'], name: 'index_tasks_on_user_id'
   end
 

--- a/tasks/schemas/tasks/assigned/1.json
+++ b/tasks/schemas/tasks/assigned/1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.Assigned.v1",
+  "description": "json schema for CUD tasks events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "user_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id",
+        "user_id"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["TaskAssigned"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/tasks/schemas/tasks/completed/1.json
+++ b/tasks/schemas/tasks/completed/1.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.Completed.v1",
+  "description": "json schema for CUD tasks events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "user_id": {
+          "type": "string"
+        },
+        "completed": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "public_id",
+        "user_id",
+        "completed"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["TaskCompleted"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/tasks/schemas/tasks/created/1.json
+++ b/tasks/schemas/tasks/created/1.json
@@ -14,7 +14,7 @@
         "title": {
           "type": "string"
         },
-        "user_id": {
+        "employee_id": {
           "type": "string"
         },
         "completed": {
@@ -30,7 +30,7 @@
       "required": [
         "public_id",
         "title",
-        "user_id",
+        "employee_id",
         "assign_cost",
         "reward"
       ]

--- a/tasks/schemas/tasks/created/1.json
+++ b/tasks/schemas/tasks/created/1.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.Created.v1",
+  "description": "json schema for CUD tasks events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "user_id": {
+          "type": "string"
+        },
+        "completed": {
+          "type": ["boolean", "null"]
+        },
+        "assign_cost": {
+          "type": "number"
+        },
+        "reward": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "public_id",
+        "title",
+        "user_id",
+        "assign_cost",
+        "reward"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["TaskCreated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/tasks/schemas/tasks/created/2.json
+++ b/tasks/schemas/tasks/created/2.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.Created.v1",
+  "description": "json schema for CUD tasks events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "format": "jira-checker"
+        },
+        "jira_id": {
+          "type": "string"
+        },
+        "employee_id": {
+          "type": "string"
+        },
+        "completed": {
+          "type": ["boolean", "null"]
+        },
+        "assign_cost": {
+          "type": "number"
+        },
+        "reward": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "public_id",
+        "title",
+        "jira_id",
+        "employee_id",
+        "assign_cost",
+        "reward"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [2] },
+    "event_name":    { "enum": ["TaskCreated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/tasks/schemas/tasks/deleted/1.json
+++ b/tasks/schemas/tasks/deleted/1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.Deleted.v1",
+  "description": "json schema for CUD tasks events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["TaskDeleted"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+

--- a/tasks/schemas/tasks/updated/1.json
+++ b/tasks/schemas/tasks/updated/1.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.Updated.v1",
+  "description": "json schema for CUD tasks events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "completed": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "public_id"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["TaskUpdated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}
+


### PR DESCRIPTION
### Schema registry + Analytics service + Accounting service
DoD:
- [x] Добавлен новый сервис `accounting` + чтение событий из кафки
- [x] Добавлен новый сервис `analytics` + чтение событий из кафки
- [x] Добавлено версионирование сообщений для кафки (схема JSON+ lib)
- [x] Миграция схемы сообщений для `task`
- [x] Логика изменений баланса попуга

ToDo:
- [ ] UI для новых сервисов
- [ ] Подсчет аналитики для дашборда
- [ ] Воркеры для сброса баланса/отправки денег в конце дня

### Реализация schema registry и эволюция данных
Выбран подход с либой, а сериализация - JSON. Схемы храним в каждом проекте в виде JSON-схемы и валидируем при отправке.